### PR TITLE
Add generic support for Lid Cover Apps

### DIFF
--- a/sdk/src/java/cyanogenmod/content/Intent.java
+++ b/sdk/src/java/cyanogenmod/content/Intent.java
@@ -141,4 +141,18 @@ public class Intent {
     public static final String ACTION_OPEN_LIVE_LOCKSCREEN_SETTINGS =
             "cyanogenmod.intent.action.OPEN_LIVE_LOCKSCREEN_SETTINGS";
 
+    /**
+     * Broadcast action: lid state changed
+     * @hide
+     */
+    public static final String ACTION_LID_STATE_CHANGED =
+            "cyanogenmod.intent.action.LID_STATE_CHANGED";
+
+    /**
+     * This field is part of the intent {@link #ACTION_LID_STATE_CHANGED}.
+     * Intent extra field for the state of lid/cover
+     * @hide
+     */
+    public static final String EXTRA_LID_STATE =
+            "cyanogenmod.intent.extra.LID_STATE";
 }


### PR DESCRIPTION
Many new devices have available flip cover cases with some form
of view window or notification options. Currently we support a
dotcase app for HTC and a View window app is under development.
Provide a new Intent to allow a common way to launch a variety
of device specific cover apps.

Change-Id: Ic986b239b75bfc6d76142451826b3f996e242a29